### PR TITLE
Fix: #BBB-116 스터디 생성 시 주차 수가 항상 1로만 요청되는 이슈

### DIFF
--- a/components/study/study-create-modal.tsx
+++ b/components/study/study-create-modal.tsx
@@ -289,6 +289,12 @@ export default function StudyCreateModal({
                     selected={addDays(startDate, weeks * DAYS_PER_WEEK)}
                     shouldCloseOnSelect // 날짜를 선택하면 datepicker가 자동으로 닫힘
                     onChange={(date) => {
+                      onChange.weeks({
+                        target: {
+                          value: dateDiff(startDate, date!) / DAYS_PER_WEEK,
+                          name: 'weeks'
+                        }
+                      });
                       setWeeks(dateDiff(startDate, date!) / DAYS_PER_WEEK);
                     }}
                     includeDates={datesFrom(
@@ -313,7 +319,12 @@ export default function StudyCreateModal({
                     } else if (Number(e.target.value) > 52) {
                       e.target.value = '52';
                     }
-                    onChange.weeks(e);
+                    onChange.weeks({
+                      target: {
+                        value: e.target.value,
+                        name: 'weeks'
+                      }
+                    });
                     setWeeks(Number(e.target.value));
                   }}
                   type="number"


### PR DESCRIPTION
## 작업 개요
<!-- 작업에 대한 요약 설명을 남겨주세요. -->
백엔드 api로 요청하는 form 내부의 weeks 값을 업데이트 하는 부분이 추가되어있지 않아, 초기값인 1로만 전달되는 이슈였습니다. 
weeks 값을 업데이트 해주는 로직을 추가하여 해결했습니다.

## 전달 사항
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->

## 참고 자료
<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->
