### PR TITLE
Feat:  자연스러운 UI / UX

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,6 @@ import { Button } from '@/components/ui/button/button';
 import { Input } from '@/components/ui/input/input';
 import { Label } from '@/components/ui/label/label';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
 
@@ -13,7 +12,6 @@ import { login } from '@/lib/api/auth/login';
 export default function Page() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const router = useRouter();
 
   const handleSubmit = async (e: any) => {
     e.preventDefault();
@@ -22,8 +20,6 @@ export default function Page() {
       const response = await login(username, password);
       const data = response.data;
       localStorage.setItem('accessToken', data.access_token);
-      console.log('data', data);
-      console.log('local', localStorage.getItem('accessToken'));
       location.href = '/';
     } catch (error) {
       console.log(error);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,15 @@
 'use client';
 
+import { userState } from '@/recoil/userAtom';
+import { useRecoilState } from 'recoil';
+
 export default function Home() {
-  return <></>;
+  const [myData, setMyData] = useRecoilState(userState);
+  return (
+    <>
+      <div className="text-center">
+        {myData?.username + '로 로그인된 상태입니다.'}
+      </div>
+    </>
+  );
 }

--- a/app/study/[id]/page.tsx
+++ b/app/study/[id]/page.tsx
@@ -5,9 +5,12 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import StudyDashBoard from '@/components/study/dashboard/dashboard';
+import JoinStudyDialog from '@/components/study/study-join-dialog';
 import Spinner from '@/components/ui/spinner/spinner';
 import getStudyDetails from '@/lib/api/study/get-details';
+import { userState } from '@/recoil/userAtom';
 import { AlgorithmRound, StudyDetails } from '@/types/study/study-detail';
+import { useRecoilState } from 'recoil';
 
 export default function StudyPage() {
   const params = useParams();
@@ -15,6 +18,8 @@ export default function StudyPage() {
 
   const [details, setDetails] = useState<StudyDetails | undefined>();
   const [round, setRound] = useState<AlgorithmRound | undefined>();
+  const [isParticipant, setIsParticipant] = useState(false);
+  const [myData, setMyData] = useRecoilState(userState);
 
   useEffect(() => {
     async function fetchStudyDetails() {
@@ -22,6 +27,14 @@ export default function StudyPage() {
         const studyDetailsAndRound = await getStudyDetails(studyId);
         setDetails(studyDetailsAndRound.details);
         setRound(studyDetailsAndRound.round);
+        for (const [userId, user] of Object.entries(
+          studyDetailsAndRound.round.users
+        )) {
+          if (userId === myData?.id.toString()) {
+            setIsParticipant(true);
+            break;
+          }
+        }
       } catch (error) {
         console.error('Failed to fetch study details:', error);
       }
@@ -40,7 +53,10 @@ export default function StudyPage() {
         round={round}
         setRound={setRound}
       />
-      <StudyAbout details={details} users={round.users} />
+      <div className="mt-4">
+        {isParticipant ? '' : <JoinStudyDialog {...details} key={studyId} />}
+        <StudyAbout details={details} users={round.users} />
+      </div>
     </div>
   );
 }

--- a/components/header/header-nav-menu.tsx
+++ b/components/header/header-nav-menu.tsx
@@ -1,14 +1,25 @@
-import Link from 'next/link';
 import { NavigationMenuLink } from '@/components/ui/navigation/navigation-menu';
+import Link from 'next/link';
 
-export default function HeaderNavMenu({ title, href }: Record<string, string>) {
+interface HeaderNavMenuProps {
+  title: string;
+  href: string;
+  icon?: React.ReactNode; // icon prop 추가
+}
+
+export default function HeaderNavMenu({
+  title,
+  href,
+  icon
+}: HeaderNavMenuProps) {
   return (
     <NavigationMenuLink asChild>
       <Link
         href={href}
-        className="group inline-flex h-9 w-max items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-medium transition-colors hover:bg-gray-100 hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-gray-100/50 data-[state=open]:bg-gray-100/50 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:focus:bg-gray-800 dark:focus:text-gray-50 dark:data-[active]:bg-gray-800/50 dark:data-[state=open]:bg-gray-800/50"
+        className="group inline-flex h-9 w-max items-center justify-center rounded-md bg-gray-100 px-4 py-2 text-sm font-medium transition-colors hover:bg-white hover:text-gray-900 focus:bg-gray-100 focus:text-gray-900 focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-gray-100/50 data-[state=open]:bg-gray-100/50 dark:hover:bg-gray-800 dark:hover:text-gray-50 dark:focus:bg-gray-800 dark:focus:text-gray-50 dark:data-[active]:bg-gray-800/50 dark:data-[state=open]:bg-gray-800/50"
         prefetch={false}
       >
+        {icon && <span className="mr-2">{icon}</span>}
         {title}
       </Link>
     </NavigationMenuLink>

--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -3,6 +3,7 @@
 import HeaderNavMenu from '@/components/header/header-nav-menu';
 import UserProfileDropDown from '@/components/header/user-profile-drop-down';
 import { Button } from '@/components/ui/button/button';
+import { LectureIcon, StudyIcon } from '@/components/ui/icon/icon';
 import {
   NavigationMenu,
   NavigationMenuList
@@ -12,15 +13,17 @@ import Link from 'next/link';
 import { me } from '@/lib/api/users/me'; // API 함수 경로에 맞게 수정
 import { userState } from '@/recoil/userAtom';
 import { usePathname } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 export default function Header() {
   const [user, setUser] = useRecoilState(userState);
   const pathname = usePathname();
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (localStorage.getItem('accessToken') === null || user !== null) {
+      setIsLoading(false);
       return;
     }
     async function fetchUser() {
@@ -29,32 +32,37 @@ export default function Header() {
         setUser(userData);
       } catch (error) {
         console.error('Failed to fetch user data:', error);
+      } finally {
+        setIsLoading(false);
       }
     }
 
     fetchUser();
   }, [user, setUser]);
 
+  if (isLoading) {
+    return null; // 로딩 중에는 아무것도 렌더링하지 않음
+  }
+
   return pathname === '/login' ? null : (
-    <header className="flex h-20 w-full shrink-0 items-center px-4 md:px-6">
+    <header className="flex h-20 w-full shrink-0 items-center px-4 md:px-6 bg-gray-100 border-b border-slate-900/10">
       <Link href="/" className="mr-6 hidden lg:flex" prefetch={false}>
         <MountainIcon className="h-6 w-6" />
         <span className="sr-only">Acme Inc</span>
       </Link>
-      <NavigationMenu className="hidden lg:flex">
+      <NavigationMenu className="hidden lg:flex bg-transparent">
         <NavigationMenuList>
-          <HeaderNavMenu title="알고리즘 스터디" href="#" />
-          <HeaderNavMenu title="기술서적 스터디" href="#" />
-          <HeaderNavMenu title="강의" href="#" />
+          <HeaderNavMenu title="스터디" href="/study" icon={<StudyIcon />} />
+          <HeaderNavMenu title="강의" href="#" icon={<LectureIcon />} />
         </NavigationMenuList>
       </NavigationMenu>
       <div className="ml-auto flex gap-2">
-        {user === null ? (
+        {user ? (
+          <UserProfileDropDown {...user} />
+        ) : (
           <Link href="/login" prefetch={false}>
             <Button>로그인</Button>
           </Link>
-        ) : (
-          <UserProfileDropDown {...user} />
         )}
       </div>
     </header>

--- a/components/study/study-grid.tsx
+++ b/components/study/study-grid.tsx
@@ -1,11 +1,11 @@
 'use client';
+import StudyGroup from '@/components/study/study-group';
 import { DEFAULT_PAGE, DEFAULT_SIZE } from '@/constants/study/study';
 import studies from '@/lib/api/study/studies';
 import { useResource } from '@/lib/utils';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { Study } from '../../types/study/study';
-import StudyJoinDialog from './study-join-dialog';
 import StudyPagination, { paging } from './study-pagination';
 
 export default function StudyGrid({ trigger }: { trigger: number }) {
@@ -19,6 +19,8 @@ export default function StudyGrid({ trigger }: { trigger: number }) {
     [page, size]
   );
 
+  const router = useRouter();
+
   useEffect(() => {
     if (page == 0) {
       refetch();
@@ -31,7 +33,14 @@ export default function StudyGrid({ trigger }: { trigger: number }) {
       <>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {studyPage?.contents.map((study: Study) => {
-            return <StudyJoinDialog key={study.id} {...study} />;
+            return (
+              <StudyGroup
+                study={study}
+                onClick={() => {
+                  router.push(`/study/${study.id}`);
+                }}
+              />
+            );
           })}
         </div>
         <StudyPagination

--- a/components/study/study-join-dialog.tsx
+++ b/components/study/study-join-dialog.tsx
@@ -9,15 +9,14 @@ import {
   DialogTitle
 } from '@/components/ui/dialog/dialog';
 import joinStudy from '@/lib/api/study/join';
+import { StudyDetails } from '@/types/study/study-detail';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
-import { Study } from '../../types/study/study';
-import StudyGroup from './study-group';
 
-export default function JoinStudyDialog(study: Study) {
+export default function JoinStudyDialog(details: StudyDetails, key: string) {
   const handleSubmit = async () => {
     try {
-      const response = await joinStudy(study.id);
+      const response = await joinStudy(parseInt(key));
       toast.success('스터디에 참여하였습니다.');
     } catch (error: any) {
       toast.error(error.response.data.error);
@@ -28,20 +27,22 @@ export default function JoinStudyDialog(study: Study) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <StudyGroup key={study.id} study={study} onClick={() => setOpen(true)} />
+      <Button className="bg-cyan-300 w-full" onClick={() => setOpen(true)}>
+        참여하기
+      </Button>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>
-            <b>{study.name}</b> 에 참여합니다.
+            <b>{details.name}</b> 에 참여합니다.
           </DialogTitle>
-          <DialogDescription>{study.introduce}</DialogDescription>
+          <DialogDescription>{details.introduce}</DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="space-y-2">
             <h4 className="">입장 조건</h4>
             <p className=" text-slate-500 dark:text-slate-400">
-              보증금 <b>{study.penalty * study.weeks}</b>원<br />
-              신뢰도 <b>{study.reliabilityLimit}</b> 이상
+              보증금 <b>{details.penalty * details.weeks}</b>원<br />
+              신뢰도 <b>{details.reliabilityLimit}</b> 이상
             </p>
           </div>
         </div>
@@ -53,7 +54,7 @@ export default function JoinStudyDialog(study: Study) {
           </div>
           <DialogClose asChild>
             <Button
-              disabled={study.capacity <= study.headCount}
+              disabled={details.capacity <= details.headCount}
               onClick={handleSubmit}
               className="
             bg-slate-900/90 text-white hover:bg-slate-900 dark:bg-slate-900 dark:hover:bg-slate-800 dark:text-slate-50

--- a/components/ui/icon/icon.tsx
+++ b/components/ui/icon/icon.tsx
@@ -320,3 +320,41 @@ export function FlagIcon(props: Record<string, string>) {
     </svg>
   );
 }
+
+export function StudyIcon(props: Record<string, string>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-6"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  );
+}
+
+export function LectureIcon(props: Record<string, string>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="size-6"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"
+      />
+    </svg>
+  );
+}

--- a/components/users/signup/signup-form.tsx
+++ b/components/users/signup/signup-form.tsx
@@ -41,7 +41,7 @@ export default function SignupForm() {
     const response = await signup(data);
     if (response.status === 200) {
       toast.success('회원가입이 완료되었습니다.');
-      router.push('/');
+      router.push('/login');
     }
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-hook-form": "^7.51.5",
         "react-toastify": "^10.0.5",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -6099,6 +6100,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.6.0",
-    "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-avatar": "^1.1.0",
+    "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.1.0",
@@ -31,6 +31,7 @@
     "react-hook-form": "^7.51.5",
     "react-toastify": "^10.0.5",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/recoil/userAtom.ts
+++ b/recoil/userAtom.ts
@@ -1,7 +1,11 @@
-import { atom } from 'recoil';
 import { User } from '@/types/user/user';
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const userState = atom<User | null>({
   key: 'userState',
-  default: null
+  default: null,
+  effects_UNSTABLE: [persistAtom]
 });


### PR DESCRIPTION
## 작업 개요
- Demo 용 메인 화면 username 추가
- 새로고침하더라도 UserState (Atom)가 소멸되지 않도록 recoil-persist 추가
- 회원가입 후 메인페이지가 아니라 로그인 화면으로 가도록 수정
- Header 아이콘 및 색 추가
- 스터디 목록에서 특정 스터디 클릭 시 해당 스터디 메인페이지로 이동하도록 수정
- 스터디에서 참여하지 않은 사람은 스터디 메인페이지에서 스터디 참여하기 버튼이 보이도록 변경

## 전달 사항

- recoil-persist 추가로 `npm install` 실행해주세요~
- 유저 정보처럼 새로고침해도 삭제되지 않아야하는 AtomState 들은 userAtom.ts 처럼 아래 1줄을 추가해주세요
  `effects_UNSTABLE: [persistAtom]`

## 참고 자료

