### PR TITLE
[BBB-150] Fix: baekjoon id를 회원가입 form에 입력했음에도 추가되지 않는 문제 해결

### DIFF
--- a/components/users/signup/signup-form.tsx
+++ b/components/users/signup/signup-form.tsx
@@ -17,7 +17,8 @@ export default function SignupForm() {
       username: z.string().trim().min(1, '빈 문자열일 수 없습니다.'),
       password: z.string().trim().min(1, '빈 문자열일 수 없습니다.'),
       checkPassword: z.string().trim().min(1, '빈 문자열일 수 없습니다'),
-      introduce: z.string().max(255, '255자 이내여야 작성해주세요.')
+      baekjoonId: z.string().max(20, '20자 이내로 작성해주세요.'),
+      introduce: z.string().max(255, '255자 이내로 작성해주세요.')
     })
     .superRefine(({ password, checkPassword }, ctx) => {
       if (password !== checkPassword) {


### PR DESCRIPTION
## 작업 개요
<!-- 작업에 대한 요약 설명을 남겨주세요. -->
회원가입 시 baekjoon Id를 추가하고 진행했음에도, baekjoonId가 null로 저장되는 문제

## 전달 사항
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->
form 에러메시지를 출력하지 않더라도 z.object(signupSchema)에 추가해줘야 함

## 참고 자료
<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->
