### PR TITLE
[BBB-137] Feat: 로그인 및 회원가입 시 종단간 암호화 적용

### DIFF
--- a/app/users/signup/page.tsx
+++ b/app/users/signup/page.tsx
@@ -1,8 +1,48 @@
 'use client';
 
 import SignupForm from '@/components/users/signup/signup-form';
+import { useEffect, useState } from 'react';
+import { PublicKeyInfo } from '@/types/encryption/public-key-info';
+import { getPublicKeyInfo } from '@/components/encryption/getPublicKeyInfo';
+import { toast } from 'react-toastify';
+import { handleEncryptedSignup } from '@/components/encryption/encryptionSignup';
 
 export default function Signup() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [baekjoonId, setBaekjoonId] = useState('');
+  const [introduce, setIntroduce] = useState('');
+  const [publicKeyInfo, setPublicKeyInfo] = useState<PublicKeyInfo | null>(
+    null
+  );
+
+  useEffect(() => {
+    try {
+      getPublicKeyInfo(setPublicKeyInfo).then(() => {
+        if (publicKeyInfo != null && username != '' && password != '') {
+          handleEncryptedSignup(
+            { username, password, baekjoonId, introduce },
+            publicKeyInfo
+          );
+        }
+      });
+    } catch (error) {
+      toast.error((error as Error).message);
+    }
+  }, []);
+
+  const handleChangeSignupInfo = (
+    username: string,
+    password: string,
+    baekjoonId: string,
+    introduce: string
+  ) => {
+    setUsername(username);
+    setPassword(password);
+    setBaekjoonId(baekjoonId);
+    setIntroduce(introduce);
+  };
+
   return (
     <div className="flex flex-col h-screen">
       <main className="flex-1 flex justify-center items-center bg-gray-100 dark:bg-gray-50">
@@ -10,7 +50,10 @@ export default function Signup() {
           <h1 className="text-black text-2xl font-bold mb-6 text-center">
             회원가입
           </h1>
-          <SignupForm />
+          <SignupForm
+            publicKeyInfo={publicKeyInfo}
+            handleChangeSignupInfo={() => handleChangeSignupInfo}
+          />
         </div>
       </main>
     </div>

--- a/components/encryption/encryptLogin.tsx
+++ b/components/encryption/encryptLogin.tsx
@@ -1,0 +1,14 @@
+import { PublicKeyInfo } from '@/types/encryption/public-key-info';
+import { login } from '@/lib/api/auth/login';
+import { encryptData } from '@/components/encryption/getPublicKeyInfo';
+
+export const handleEncryptedLogin = async (
+  loginInfo: {
+    username: string;
+    password: string;
+  },
+  publicKeyInfo: PublicKeyInfo
+) => {
+  const encryptedData = encryptData(loginInfo, publicKeyInfo);
+  return await login(publicKeyInfo.id, publicKeyInfo.version, encryptedData);
+};

--- a/components/encryption/encryptionSignup.tsx
+++ b/components/encryption/encryptionSignup.tsx
@@ -1,0 +1,11 @@
+import { PublicKeyInfo } from '@/types/encryption/public-key-info';
+import { encryptData } from '@/components/encryption/getPublicKeyInfo';
+import { signup } from '@/lib/api/users/signup';
+
+export const handleEncryptedSignup = async (
+  signupInfo: Record<string, string>,
+  publicKeyInfo: PublicKeyInfo
+) => {
+  const encryptedData = encryptData(signupInfo, publicKeyInfo);
+  return await signup(publicKeyInfo.id, publicKeyInfo.version, encryptedData);
+};

--- a/components/encryption/getPublicKeyInfo.tsx
+++ b/components/encryption/getPublicKeyInfo.tsx
@@ -1,0 +1,28 @@
+import fetchPublicKey from '@/lib/api/encryption/fetch-public-key';
+import { PublicKeyInfo } from '@/types/encryption/public-key-info';
+import { Dispatch, SetStateAction } from 'react';
+import { JSEncrypt } from 'jsencrypt';
+
+export const getPublicKeyInfo = async (
+  setPublicKeyInfo: Dispatch<SetStateAction<PublicKeyInfo | null>>
+) => {
+  try {
+    const res = await fetchPublicKey();
+    setPublicKeyInfo(res.data);
+  } catch (err) {
+    throw new Error('보안 설정에 실패했습니다. 잠시 후에 시도해주세요.');
+  }
+};
+
+export const encryptData = (
+  data: Record<string, string>,
+  publicKeyInfo: PublicKeyInfo
+) => {
+  const encrypt = new JSEncrypt();
+  encrypt.setPublicKey(publicKeyInfo.publicKey);
+  const encryptedData = encrypt.encrypt(JSON.stringify(data));
+  if (encryptedData === false) {
+    throw new Error('암호화에 실패했습니다.');
+  }
+  return encryptedData;
+};

--- a/lib/api/auth/login.ts
+++ b/lib/api/auth/login.ts
@@ -4,9 +4,26 @@ import axios from 'axios';
  * 로그인 API
  * body : username, password
  */
-export function login(username: string, password: string) {
-  return axios.post(`${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/v1/auth`, {
-    username: username,
-    password: password
-  });
+export async function login(
+  id: number,
+  version: number,
+  encryptedData: string
+) {
+  try {
+    return await axios.post(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/v1/auth`,
+      {
+        id,
+        version,
+        encryptedData
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  } catch (error) {
+    throw new Error('아이디 또는 패스워드가 틀렸습니다.');
+  }
 }

--- a/lib/api/encryption/fetch-public-key.ts
+++ b/lib/api/encryption/fetch-public-key.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+/**
+ * 종단간 암호화 적용을 위한 서버의 public key 조회 API
+ */
+
+export default function fetchPublicKey() {
+  return axios.get(
+    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/v1/encryption/public-key`
+  );
+}

--- a/lib/api/users/signup.ts
+++ b/lib/api/users/signup.ts
@@ -1,18 +1,33 @@
-import axios from 'axios';
-import { FieldValues } from 'react-hook-form';
+import axios, { AxiosError } from 'axios';
 
 /**
  * 회원가입 API
  * body : username, password, baekjoonId, introduce
  */
-export async function signup({
-  username,
-  password,
-  baekjoonId,
-  introduce
-}: FieldValues) {
-  return await axios.post(
-    `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/v1/users/signup`,
-    { username, password, baekjoonId, introduce }
-  );
+export async function signup(
+  id: number,
+  version: number,
+  encryptedData: string
+) {
+  try {
+    return await axios.post(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/api/v1/users/signup`,
+      {
+        id,
+        version,
+        encryptedData
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    if (axiosError.response?.status === 409) {
+      throw new Error('이미 존재하는 아이디입니다.');
+    }
+    throw new Error('회원가입에 실패했습니다.');
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "eslint-config-prettier": "^9.1.0",
+        "jsencrypt": "^3.3.2",
         "lucide-react": "^0.394.0",
         "next": "14.2.4",
         "react": "^18.3.1",
@@ -5250,6 +5251,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsencrypt": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/jsencrypt/-/jsencrypt-3.3.2.tgz",
+      "integrity": "sha512-arQR1R1ESGdAxY7ZheWr12wCaF2yF47v5qpB76TtV64H1pyGudk9Hvw8Y9tb/FiTIaaTRUyaSnm5T/Y53Ghm/A==",
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "eslint-config-prettier": "^9.1.0",
+    "jsencrypt": "^3.3.2",
     "lucide-react": "^0.394.0",
     "next": "14.2.4",
     "react": "^18.3.1",

--- a/types/encryption/public-key-info.ts
+++ b/types/encryption/public-key-info.ts
@@ -1,0 +1,5 @@
+export interface PublicKeyInfo {
+  id: number;
+  version: number;
+  publicKey: string;
+}

--- a/types/user/signup-form-props.ts
+++ b/types/user/signup-form-props.ts
@@ -1,0 +1,11 @@
+import { PublicKeyInfo } from '@/types/encryption/public-key-info';
+
+export interface SignupFormProps {
+  publicKeyInfo: PublicKeyInfo | null;
+  handleChangeSignupInfo: (
+    username: string,
+    password: string,
+    baekjoonId: string,
+    introduce: string
+  ) => void;
+}


### PR DESCRIPTION
## 작업 개요
<!-- 작업에 대한 요약 설명을 남겨주세요. -->
로그인과 회원가입 진행 시, API 서버로부터 받은 public key를 가지고 request body를 암호화 시켜 요청 

## 전달 사항
<!-- 작업과 관련된 전달 사항을 남겨주세요. -->
서버에서 진행되는 로직은 다음 PR을 참고해주세요
[Feat: #BBB-136 로그인 및 회원가입 시 클라이언트와 서버 간 종단간 암호화 적용 #57](https://github.com/Team-BomBomBom/Server/pull/57)

## 참고 자료
<!-- 작업 시 참고했던 자료의 출처를 남겨주세요. -->
